### PR TITLE
Adds usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Mod to Automatically Skip Intros
 
-A simple Docker mod for (linuxserver/plex)[https://hub.docker.com/r/linuxserver/plex] to automatically skip intros .
+A simple Docker mod for [linuxserver/plex](https://hub.docker.com/r/linuxserver/plex) to automatically skip intros .
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-A simple docker mod to automatically skip intros
+# Docker Mod to Automatically Skip Intros
+
+A simple Docker mod for (linuxserver/plex)[https://hub.docker.com/r/linuxserver/plex] to automatically skip intros .
+
+## Usage
+
+Add the environment variable `DOCKER_MODS=caedis/plex-auto-skip-intro` to your Plex Docker container.


### PR DESCRIPTION
I found this repo [on Reddit](https://old.reddit.com/r/PleX/comments/rw0ka7/i_give_you_plexautoskipintro_a_docker_mod_for/) and wanted to star it, but noticed that there weren't usage instructions here, so I adapted the usage instructions from the Reddit post and added them to the README.